### PR TITLE
Admin menu item "C9 Theme" duplication

### DIFF
--- a/admin/admin-settings.php
+++ b/admin/admin-settings.php
@@ -74,7 +74,8 @@ if ( class_exists( 'WP_OSA' ) ) {
 	 *
 	 * Object for the class `WP_OSA`.
 	 */
-	$wposa_obj = new WP_OSA();
+	if (empty($wposa_obj))
+		$wposa_obj = new WP_OSA();
 
 
 	// -----------------------------//


### PR DESCRIPTION
If the client boilerplate is provided, since it takes precedence over the standard theme settings the `$wposa_obj` is already initialised. By redeclaring it we redo the initialisation, hooks included, on two different items, and this might not be the desired scenario. Having two separate objects is useless anyway, since both menu items point to the same settings with everything included anyway.

Haven't tested for namespace collisions between client and parent, though.