### PR TITLE
Fix webfonts failing when heading font not set

### DIFF
--- a/assets/scripts/typography-script.js
+++ b/assets/scripts/typography-script.js
@@ -15,7 +15,10 @@ if (c9SelectedFonts.c9_default_font === "yes") {
 	//alert(c9SelectedFonts.c9_body_font);
 
 	c9QueuedFonts = [];
-	c9QueuedFonts.push(c9SelectedFonts.c9_heading_font);
+	
+	if (c9SelectedFonts.c9_heading_font) {
+		c9QueuedFonts.push(c9SelectedFonts.c9_heading_font);
+	}
 
 	if (c9SelectedFonts.c9_subheading_font != c9SelectedFonts.c9_heading_font) {
 		c9QueuedFonts.push(c9SelectedFonts.c9_subheading_font);


### PR DESCRIPTION
I was testing the options and noticed setting a body or subheading font without setting a heading font causes the webfonts to fail to load.
Apparently passing an empty string to the Web Font Loader makes the entire request fail, so a tiny change removes it.
As a result the headings default to the body's font in this case but I'm not sure if this is your intention because without a setting the headings are defined as `font-family: ,helvetica,sans-serif;`, which browsers see as an error and ignore.